### PR TITLE
Fix Deprecated Github Commands

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,7 +74,7 @@ jobs:
       matrix: ${{ fromJson(needs.env.outputs.matrix) }}
     steps:
       - name: Check out
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Disallow Concurrent Runs
         uses: byu-oit/github-action-disallow-concurrent-runs@v2
@@ -83,7 +83,7 @@ jobs:
 
       - name: Configure AWS Credentials
         id: awscreds
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets[matrix.env.aws_key_name] }}
           aws-secret-access-key: ${{ secrets[matrix.env.aws_secret_name] }}


### PR DESCRIPTION
This is a best attempt pull request to upgrade outdated actions. Failure to upgrade may mean your actions stop working on June 1st, 2023. We only targeted one branch (usually development) and you can deploy those changes to other branches. Some workflows may need extra tweaking to work. Feel free to contact Jamie Visker if you have questions or want another branch targeted.